### PR TITLE
Update hyper-util for enabled feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ hyper-openssl = "0.10.2"
 hyper-rustls = { version = "0.27.1", default-features = false }
 hyper-socks2 = { version = "0.9.0", default-features = false }
 hyper-timeout = "0.5.1"
-hyper-util = "0.1.9"
+hyper-util = "0.1.11"
 json-patch = "4"
 jsonpath-rust = "0.7.3"
 k8s-openapi = { version = "0.24.0", default-features = false }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

https://github.com/kube-rs/kube/pull/1734/files enabled the new `tracing` feature on the `hyper-util` crate. This feature was introduced in version `0.1.11`, but we're locked to `0.1.9`. 

This led to this compile error when I pointed my local repo at the latest commit:

![image](https://github.com/user-attachments/assets/79b039b3-5b7b-4bf4-8015-bbfdb386e7dd)


<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

Upgrade the dependency.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
